### PR TITLE
Use select2 on all data search select boxes

### DIFF
--- a/app/views/catalogs/_advanced_search.html.haml
+++ b/app/views/catalogs/_advanced_search.html.haml
@@ -14,13 +14,16 @@
       #general.accordion-body.collapse
         .accordion-inner
           = label_tag 'search[type]', 'Record Type'
-          = select_tag 'search[type]', options_for_select([['Projects', 'Project'], ['Data', 'Asset']], search_params[:type]), class: 'span12', prompt: "Projects and Data"
+          = select_tag 'search[type]', options_for_select([['Projects', 'Project'], ['Data', 'Asset']], search_params[:type]), class: 'span12', 
+            data: {placeholder: 'Projects and Data'}, include_blank: true
 
           = label_tag 'search[data_types]', 'Data Type'
-          = select_tag 'search[data_types]', options_from_collection_for_select(DataType.all, :name, :name, search_params[:data_types]), class: 'span12', prompt: 'All types'
+          = select_tag 'search[data_types]', options_from_collection_for_select(DataType.all, :name, :name, search_params[:data_types]), class: 'span12',
+            data: {placeholder: 'All types'}, include_blank: true
 
           = label_tag 'search[status]', 'Status'
-          = select_tag 'search[status]', options_for_select(Project::STATUSES + Asset::STATUSES, search_params[:status]), class: 'span12', prompt: 'Any'
+          = select_tag 'search[status]', options_for_select(Project::STATUSES + Asset::STATUSES, search_params[:status]), class: 'span12', 
+            data: {placeholder: 'Any'}, include_blank: true
 
           = label_tag 'search[start_date_afer]', 'Starts after'
           = number_field_tag 'search[start_date_afer]', search_params[:start_date_afer], min: 1900, max: Time.zone.now.year, class: 'span12', placeholder: 'YYYY'
@@ -29,7 +32,8 @@
           = number_field_tag 'search[end_date_before]', search_params[:end_date_before], min: 1900, max: Time.zone.now.year, class: 'span12', placeholder: 'YYYY'
               
           = label_tag 'search[region]', 'Region'
-          = select_tag 'search[region]', options_from_collection_for_select(Geokeyword.all, :name, :name, search_params[:region]), class: 'span12', prompt: 'All regions'
+          = select_tag 'search[region]', options_from_collection_for_select(Geokeyword.all, :name, :name, search_params[:region]), class: 'span12', 
+            data: {placeholder: 'All regions'}, include_blank: true
 
           = label_tag 'search[long_term_monitoring]', class: 'checkbox' do
             = check_box_tag 'search[long_term_monitoring]', 1, search_params[:long_term_monitoring]
@@ -65,4 +69,4 @@
             class: 'span12', data: {placeholder: 'All Contacts'}
             
 :javascript
-  $("#agencies select, #contacts select").select2({allowClear: true});              
+  $("select").select2({allowClear: true});              


### PR DESCRIPTION
All select tags on the data search page now use select2 for a consistant look and feel
