### PR TITLE
Change dalli to dalli_store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
     servers = ENV['MEMCACHE_SERVERS'].split(",")
     namespace = ENV['MEMCACHE_NAMESPACE'] || 'glynx'
 
-    config.cache_store = :dalli, servers, { namespace: namespace }
+    config.cache_store = :dalli_store, servers, { namespace: namespace }
   end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
This fixes the cache store configuration to use the correct name for dalli. 
